### PR TITLE
change GUI import warning to use `warnings.warn()`

### DIFF
--- a/plink_src/gui.py
+++ b/plink_src/gui.py
@@ -29,7 +29,8 @@ try:
 except ImportError:
     # Tk is unavailable or misconfigured.
     # This allows running tests when there is no tkinter module.
-    print('Plink failed to import tkinter.')
+    import warnings
+    warnings.warn('Plink failed to import tkinter, GUI will not be available')
     Tk_ = ttk = tkFileDialog = tkMessageBox = SimpleDialog = None
 
 from urllib.request import pathname2url


### PR DESCRIPTION
On import, plink emits a warning if `tkinter` cannot be imported. This is done via a direct call to `print()`, which makes it very hard to suppress.

Change  the `print()` to use the python stdlib `warnings.warn()` so that `warnings.filterWarnings()` can be used to silence it.

Motivation: `snappy` (used by PyArrow) requires `plink`, but a lot of of the time it's being used on systems without `tkinter`. This makes everything that imports PyArrow or Snappy print the `Plink failed to import tkinter` warning on startup, which is quite confusing if you don't know where it's coming from.

While yes, it's dumb that a *compression library* has `plink` as a dependency - wtf? - and should be properly fixed by making the dependency optional on their end, it's still best practice to use `warnings` for things like this and making it filterable is probably a good idea in general.

Feel free to reject this, but I figure it can't hurt to ask.